### PR TITLE
Add arm64 to supported repository architectures

### DIFF
--- a/package_server/conf/distributions
+++ b/package_server/conf/distributions
@@ -2,7 +2,7 @@ Origin: package.edulution.io
 Label: package.edulution.io
 Codename: nobel
 AlsoAcceptFor: noble
-Architectures: i386 amd64 source
+Architectures: i386 amd64 arm64 source
 Components: main
 Description: Ubuntu 24.04 (noble) stable
 SignWith: BD35E6DB4655161B
@@ -10,7 +10,7 @@ SignWith: BD35E6DB4655161B
 Origin: package.edulution.io
 Label: package.edulution.io
 Codename: resolute
-Architectures: i386 amd64 source
+Architectures: i386 amd64 arm64 source
 Components: main
 Description: Ubuntu 26.04 (resolute) stable
 SignWith: BD35E6DB4655161B


### PR DESCRIPTION
## Problem

The `edulution-fileproxy` 1.2.0 build (PR #31) ships an arm64 package for the first time. `package_server/conf/distributions` only declared `i386 amd64 source`, so reprepro rejected the arm64 `.changes` file:

```
'edulution-fileproxy_1.2.0_arm64.changes' contains 'edulution-fileproxy_1.2.0_arm64.deb' not matching an valid architecture in any distribution known!
```

This is a hard error, so `reprepro processincoming` aborted with exit code 255 before `reprepro -V export` could run — hence the follow-up warnings about databases being modified without an exported index.

## Change

Declare `arm64` for both the `nobel`/`noble` and `resolute` distributions.

## Verification

Ran the CI build steps against the PR #31 tree in an `ubuntu:noble` container (with `SignWith` stripped):

- `reprepro -V processincoming default` → exit 0
- `reprepro -V export` → exit 0
- `reprepro list nobel` lists `edulution-fileproxy 1.2.0` in both `nobel|main|amd64` and `nobel|main|arm64`