### PR TITLE
Publish packages for all Ubuntu versions and rename nobel to noble

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,10 +36,15 @@ jobs:
             echo "No packages found, skipping processincoming"
           fi
 
+          # Make every package available in all configured Ubuntu releases
+          # (packages are usually uploaded for a single codename only)
+          bash sync-distributions.sh
+
           reprepro -V export
 
-          # Create symlink so both 'nobel' (legacy typo) and 'noble' (correct) URLs work
-          ln -s nobel dists/noble
+          # Create symlink so the legacy typo URL 'nobel' keeps working for
+          # clients that still have it in their sources.list
+          ln -s noble dists/nobel
 
           # Generate package list JSON for main page
           bash generate-package-json.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ sudo apt-get install edulution-fileproxy
 > `dists/nobel -> noble` keeps the old URL working for existing clients. Both
 > can be dropped once no client uses `nobel` any more.
 
+### One-time migration after the rename
+
+Clients that used the repository **before** the rename have `Codename: nobel`
+in their APT cache. Because APT refuses updates after release-information
+changes, the first `apt update` after the rename fails:
+
+```
+E: Repository 'https://package.edulution.io noble Release' changed its
+   'Codename' value from 'nobel' to 'noble'
+```
+
+`apt-get update` exits with code 100 and the package list of this repository
+is not refreshed, which also breaks unattended upgrades and any automation.
+The change has to be accepted once per machine:
+
+```bash
+sudo apt update --allow-releaseinfo-change
+```
+
+Afterwards `apt update` works as before. Newly set up machines are unaffected.
+
 ---
 
 ## Repository layout
@@ -105,6 +126,13 @@ and imports it.
 > If a distribution needs its own build, place it under
 > `packages/<package-name>/<codename>/` – an existing package is never
 > overwritten by a copy from another distribution.
+>
+> The check is per package **name**: as soon as a distribution contains a
+> package of that name, it is left alone completely, including all its
+> architectures and regardless of version. A distribution-specific build
+> therefore has to be maintained on its own – it does not receive the newer
+> version from another distribution. The build logs every such case as
+> `Skipping <package> for <distribution> (already present)`.
 
 > In practice, the individual package repositories (e.g.
 > `edulution-fileproxy`) push their releases via automation into an

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ sudo apt-get install edulution-fileproxy
 | 24.04 LTS        | `noble`    | active               |
 | 26.04 LTS        | `resolute` | active               |
 
-> Note: For historical reasons the `noble` distribution is internally named
-> `nobel` (a typo). Thanks to `AlsoAcceptFor: noble` and a symlink
-> (`dists/noble -> nobel`), the correct `noble` URL works regardless. New
-> distributions should be created with the correct codename right away.
+> Note: The `noble` distribution used to be named `nobel` (a typo). It is now
+> called `noble` everywhere; the old name only survives as a compatibility
+> layer – `AlsoAcceptFor: nobel` accepts old uploads and the symlink
+> `dists/nobel -> noble` keeps the old URL working for existing clients. Both
+> can be dropped once no client uses `nobel` any more.
 
 ---
 
@@ -55,10 +56,11 @@ sudo apt-get install edulution-fileproxy
 │   └── <package-name>/<codename>/ # e.g. edulution-fileproxy/noble/...
 ├── package_server/               # Source of the published repository
 │   ├── conf/
-│   │   ├── distributions         # reprepro: distributions (noble/nobel, resolute)
+│   │   ├── distributions         # reprepro: distributions (noble, resolute)
 │   │   └── incoming              # reprepro: incoming configuration
 │   ├── pub.gpg                   # public signing key
 │   ├── index.html                # landing page (instructions + package list)
+│   ├── sync-distributions.sh     # copies packages into all distributions
 │   ├── generate-package-json.sh  # generates packages.json for the landing page
 │   ├── generate-indices.sh       # generates index.html for directory browsing
 │   └── media/                    # logo/background for the landing page
@@ -97,6 +99,13 @@ and imports it.
 3. Commit the change. A push to `main` builds and deploys the repository
    automatically (see below).
 
+> A package only has to be uploaded for **one** codename. During the build,
+> `sync-distributions.sh` copies it into every other distribution, so a package
+> uploaded under `noble` is also available for Ubuntu 26.04 (`resolute`).
+> If a distribution needs its own build, place it under
+> `packages/<package-name>/<codename>/` – an existing package is never
+> overwritten by a copy from another distribution.
+
 > In practice, the individual package repositories (e.g.
 > `edulution-fileproxy`) push their releases via automation into an
 > `update/...` branch of this repo. The
@@ -112,7 +121,9 @@ and imports it.
 3. Add the codename to the `FALLBACK_DISTS` list in
    [`package_server/index.html`](package_server/index.html) (only relevant for
    the display when `packages.json` is unreachable).
-4. Place packages under `packages/<package-name>/<codename>/`.
+4. Optional: place distribution-specific packages under
+   `packages/<package-name>/<codename>/`. All other packages are copied into
+   the new distribution automatically during the build.
 
 The client instructions do **not** need to be changed – they detect the
 codename automatically.
@@ -129,13 +140,16 @@ directory:
    `GPG_PRIVATE_KEY` secret).
 2. Copy existing `.deb` packages from `../packages/*/*/*` into `incoming/` and
    import them with `reprepro processincoming default`.
-3. Generate the repository indices with `reprepro export`.
-4. Create the symlink `dists/noble -> nobel` (compatibility, see above).
-5. `generate-package-json.sh` generates `packages.json` (the landing page's
+3. `sync-distributions.sh` copies every package into all distributions
+   configured in `conf/distributions`, unless the distribution already
+   contains a package of that name.
+4. Generate the repository indices with `reprepro export`.
+5. Create the symlink `dists/nobel -> noble` (legacy URL, see above).
+6. `generate-package-json.sh` generates `packages.json` (the landing page's
    package list, across **all** distributions).
-6. `generate-indices.sh` generates `index.html` files for browsing the
+7. `generate-indices.sh` generates `index.html` files for browsing the
    `dists/` and `pool/` directories.
-7. **Deploy** (only on `main`): the contents of `package_server/` are published
+8. **Deploy** (only on `main`): the contents of `package_server/` are published
    to GitHub Pages (branch `package_server`).
 
 ### Required secrets
@@ -157,6 +171,7 @@ is installed:
 
 ```bash
 cd package_server
+bash sync-distributions.sh         # copy packages into all distributions
 reprepro -V export                 # generate indices (uses conf/ + pool/)
 bash generate-package-json.sh      # build packages.json
 bash generate-indices.sh           # build directory indices

--- a/package_server/conf/distributions
+++ b/package_server/conf/distributions
@@ -1,7 +1,7 @@
 Origin: package.edulution.io
 Label: package.edulution.io
-Codename: nobel
-AlsoAcceptFor: noble
+Codename: noble
+AlsoAcceptFor: nobel
 Architectures: i386 amd64 arm64 source
 Components: main
 Description: Ubuntu 24.04 (noble) stable

--- a/package_server/generate-package-json.sh
+++ b/package_server/generate-package-json.sh
@@ -4,9 +4,9 @@
 #
 # All distributions under dists/ are scanned, so the package list on the
 # landing page is not tied to a single Ubuntu release. Symlinked distribution
-# directories (e.g. dists/noble -> nobel) are skipped automatically because
-# `find` does not descend into symlinked directories, which keeps the list
-# free of duplicates.
+# directories (e.g. the legacy dists/nobel -> noble) are skipped automatically
+# because `find` does not descend into symlinked directories, which keeps the
+# list free of duplicates.
 
 echo "Generating packages.json..."
 
@@ -53,9 +53,6 @@ emit_entry() {
 for pkg_file in "${PACKAGES_FILES[@]}"; do
     # dists/<codename>/<component>/binary-<arch>/Packages -> <codename>
     dist=$(echo "$pkg_file" | sed -E 's|^dists/([^/]+)/.*|\1|')
-    # Normalise the legacy typo codename for display (the real dir is "nobel",
-    # exposed to users as "noble" via AlsoAcceptFor and a symlink).
-    [ "$dist" = "nobel" ] && dist="noble"
 
     package_name="" version="" arch="" size="" filename=""
     while IFS= read -r line; do

--- a/package_server/index.html
+++ b/package_server/index.html
@@ -265,6 +265,17 @@
             Der Befehl in Schritt 2 erkennt die installierte Version automatisch über <code>/etc/os-release</code>.
         </div>
 
+        <div class="note">
+            <strong>Einmalige Meldung nach der Umbenennung:</strong> Die Distribution hieß intern früher
+            <code>nobel</code> und heißt jetzt korrekt <code>noble</code>. Auf Systemen, die das Repository
+            vorher schon eingebunden hatten, bricht <code>apt update</code> deshalb einmalig mit
+            <em>„… changed its 'Codename' value from 'nobel' to 'noble'“</em> ab. Einmal bestätigen genügt:
+            <div class="code-block">
+                <code>sudo apt update --allow-releaseinfo-change</code>
+            </div>
+            Danach funktioniert <code>apt update</code> wieder wie gewohnt. Neu eingerichtete Systeme sind nicht betroffen.
+        </div>
+
         <h2>📋 Verfügbare Pakete</h2>
         <!-- One section per package, filled by JavaScript from packages.json -->
         <div id="package-list"></div>

--- a/package_server/sync-distributions.sh
+++ b/package_server/sync-distributions.sh
@@ -12,7 +12,10 @@
 # A distribution-specific build always wins: if a package name already exists
 # in a distribution, it is never overwritten by a copy from another one.
 
-set -e
+# pipefail matters here: packages_in() pipes reprepro into sort, and without it
+# a failing "reprepro list" would look like an empty distribution instead of
+# aborting the build.
+set -eo pipefail
 
 CODENAMES=$(awk '/^Codename:/ {print $2}' conf/distributions)
 

--- a/package_server/sync-distributions.sh
+++ b/package_server/sync-distributions.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Script to make every package available in all configured distributions.
+#
+# Packages are usually uploaded for a single Ubuntu release only (the
+# .changes file carries e.g. "Distribution: noble"), so reprepro imports them
+# into that distribution alone. The edulution packages are not tied to a
+# specific Ubuntu release, therefore they are copied into every other
+# distribution listed in conf/distributions as well - e.g. so that Ubuntu
+# 26.04 (resolute) clients get the packages built for noble.
+#
+# A distribution-specific build always wins: if a package name already exists
+# in a distribution, it is never overwritten by a copy from another one.
+
+set -e
+
+CODENAMES=$(awk '/^Codename:/ {print $2}' conf/distributions)
+
+# Names of all packages currently present in a distribution.
+packages_in() {
+    reprepro list "$1" | awk '{print $2}' | sort -u
+}
+
+for dst in $CODENAMES; do
+    for src in $CODENAMES; do
+        [ "$src" = "$dst" ] && continue
+
+        # Re-read after every source, so a package copied from an earlier
+        # source is not copied a second time from a later one.
+        existing=$(packages_in "$dst")
+
+        for pkg in $(packages_in "$src"); do
+            if grep -qxF "$pkg" <<< "$existing"; then
+                echo "Skipping $pkg for $dst (already present)"
+                continue
+            fi
+            echo "Copying $pkg from $src to $dst"
+            reprepro -V copy "$dst" "$src" "$pkg"
+        done
+    done
+done
+
+echo "Distributions synchronised."


### PR DESCRIPTION
Packages are uploaded for a single codename only (the `.changes` file carries e.g. `Distribution: noble`), so `reprepro` imported them into that distribution alone — Ubuntu 26.04 (`resolute`) clients got nothing, even though the distribution has been configured for a while.

## Changes

**Publish packages for every configured distribution**

* New `package_server/sync-distributions.sh`: reads all `Codename:` entries from `conf/distributions` and copies each package into the distributions it is missing from. The build calls it between `processincoming` and `export`.
* A distribution-specific build always wins — a package name already present in a distribution is never overwritten by a copy from another one. So a dedicated `resolute` build under `packages/<name>/resolute/` keeps precedence.
* Both distributions reference the same `pool/` files, nothing is duplicated on disk.

**Rename the distribution `nobel` to `noble`**

* The codename is now spelled correctly, which removes the display special case in `generate-package-json.sh`.
* The old name stays available for compatibility: `AlsoAcceptFor: nobel` accepts old uploads, and the symlink is inverted to `dists/nobel -> noble` so clients with the old URL in their `sources.list` keep working.
* Safe to rename because `db/` and `pool/` are not committed but rebuilt from `packages/` on every run.

**Group the package list on the landing page** (previous commit)

* An `Architecture: all` package is written to every `binary-<arch>` index, so it appeared once per architecture in the list — three times now that arm64 is supported. Entries are deduplicated in `generate-package-json.sh` and again at render time.
* One section per package instead of a flat table, newest version first, with human-readable sizes.

## Testing

Ran the complete build steps locally with `reprepro` and the packages from `packages/`:

```
Copying edulution-eventhandler from noble to resolute
Copying edulution-fileproxy from noble to resolute

dists/: noble  resolute  nobel -> noble
Release Codename: noble / resolute
```

* `packages.json` afterwards lists both packages for `noble` and `resolute`.
* Re-running `sync-distributions.sh` is a no-op (`Skipping <pkg> for <dist> (already present)`).
* A legacy `.changes` file with `Distribution: nobel` is still accepted and lands in `noble`.
* Simulated the landing-page rendering against the generated `packages.json`: one section per package, one row per distribution, correct `Ubuntu 24.04 (noble)` / `Ubuntu 26.04 (resolute)` labels.

## Note

The packages are not actually *built* for Ubuntu 26.04 — the noble build is published for resolute as well. Uncritical for `Architecture: all` packages like `edulution-eventhandler`; for the amd64 binary `edulution-fileproxy` it depends on whether it links against libraries that changed in 26.04. If that becomes an issue, the clean fix is a dedicated build pushed to `packages/edulution-fileproxy/resolute/`, which the script respects automatically.